### PR TITLE
Changed aboutVersion to aboutRevision in lacking places

### DIFF
--- a/doc/examples/comment-queries.md
+++ b/doc/examples/comment-queries.md
@@ -16,7 +16,7 @@ SELECT ?r ?status_name ?author WHERE {
         ?new rev:replaces ?r.
     }
     ?review a review:Review;
-        review:aboutVersion ?r.
+        review:aboutRevision ?r.
     ?review a ?status;
         review:issuedBy ?author.
     ?status rdfs:subClassOf review:ReviewState;
@@ -40,7 +40,7 @@ prefix review: <https://rdf.equinor.com/ontology/review/>
 SELECT ?reply ?comment ?object ?author  WHERE {
   
     ?reply a review:Review;
-        review:aboutVersion exdoc:A123-BC-D-EF-00001.F01;
+        review:aboutRevision exdoc:A123-BC-D-EF-00001.F01;
         review:hasComment ?c.
     ?c review:aboutObject ?object ;
         rdfs:label ?comment ;
@@ -73,7 +73,7 @@ prefix rev: <https://rdf.equinor.com/ontology/revision/>
 SELECT distinct ?document ?newest_revision_name ?status_name ?reply_name ?reply_date ?comment_responsible WHERE {
     GRAPH ?record1 {
         ?reply a review:Review, ?status;
-            review:aboutVersion ?revision;
+            review:aboutRevision ?revision;
             rdfs:label ?reply_name;
             prov:generatedAtTime ?reply_date;
             review:issuedBy ?comment_responsible.
@@ -114,7 +114,7 @@ SELECT distinct ?document ?revision ?comment_text ?author ?comment_responsible ?
     GRAPH rec:HeadContent {
         ?reply a review:Review;
             review:issuedBy ?comment_responsible;
-            review:aboutVersion ?revision;
+            review:aboutRevision ?revision;
             review:hasComment ?comment.
         ?comment a review:Comment;
             rdfs:label ?comment_text;

--- a/doc/examples/rdfox/abouttag.sparql
+++ b/doc/examples/rdfox/abouttag.sparql
@@ -1,8 +1,7 @@
 SELECT * WHERE {
-    GRAPH rec:HeadContent {
     ?reply a review:Review;
         review:issuedBy ?comment_responsible;
-        review:aboutVersion ?revision;
+        review:aboutRevision ?revision;
         review:hasComment ?comment.
         ?comment a review:Comment;
         rdfs:label ?comment_text;
@@ -12,5 +11,4 @@ SELECT * WHERE {
         ?row mel:tagNumber ?tagNumber .
        
         ?revision rev:describes ?document.
-    }
 }

--- a/doc/examples/rdfox/allcomments.sparql
+++ b/doc/examples/rdfox/allcomments.sparql
@@ -1,14 +1,12 @@
 SELECT ?reply ?comment ?object ?author  WHERE {
-    GRAPH rec:HeadContent {
   
     ?reply a review:Review;
-        review:aboutVersion exdoc:A123-BC-D-EF-00001.F01;
+        review:aboutRevision exdoc:A123-BC-D-EF-00001.F01;
         review:hasComment ?c.
     ?c review:aboutObject ?object ;
         rdfs:label ?comment ;
         review:issuedBy ?author.
     OPTIONAL {
         ?c review:aboutProperty ?property.
-    }
     }
 } 

--- a/doc/examples/rdfox/allreviewstatus.sparql
+++ b/doc/examples/rdfox/allreviewstatus.sparql
@@ -1,7 +1,7 @@
 SELECT distinct ?document ?newest_revision_name ?status_name ?reply_name ?reply_date ?comment_responsible WHERE {
     GRAPH ?record1 {
         ?reply a review:Review, ?status;
-            review:aboutVersion ?revision;
+            review:aboutRevision ?revision;
             rdfs:label ?reply_name;
             prov:generatedAtTime ?reply_date;
             review:issuedBy ?comment_responsible.

--- a/doc/examples/rdfox/alltriples.sparql
+++ b/doc/examples/rdfox/alltriples.sparql
@@ -1,0 +1,3 @@
+select ?s where {
+        ?s a review:Comment.
+}

--- a/doc/examples/rdfox/commit-procedure.q
+++ b/doc/examples/rdfox/commit-procedure.q
@@ -1,8 +1,4 @@
-INSERT {
-    GRAPH rec:HeadContent {?s ?p ?o}
-} WHERE {
-    GRAPH ?rec {?rec a rec:Record. ?s ?p ?o}
-}
+
 INSERT { 
     ?s a <https://rdfox.com/vocabulary#ConstraintViolation> . 
     ?s ?p ?o 

--- a/doc/examples/rdfox/review.rdfox
+++ b/doc/examples/rdfox/review.rdfox
@@ -1,15 +1,15 @@
 # Script for running the comments2 example in rdfox
 # Expects to be run from this folder from inside rdfox after endpoint start
-dstore create comment
-active comment
 set output out
+dstore create comment default-graph-name <https://rdf.equinor.com/ontology/record/HeadContent> 
+active comment
 prefixes.rdfox
 
 #Import ontologies
-import   ../../../schema/revision.ttl
-import   ../../../schema/review.ttl
-import   ../../../../records/schema/record-syntax.ttl
-importaxioms   > rec:HeadContent 
+import > ex:schema  ../../../schema/revision.ttl
+import > ex:schema  ../../../schema/review.ttl
+import > ex:schema  ../../../../records/schema/record-syntax.ttl
+importaxioms  ex:schema > rec:HeadContent 
 
 
 #Import shacl shapes

--- a/doc/examples/rdfox/status.sparql
+++ b/doc/examples/rdfox/status.sparql
@@ -1,14 +1,13 @@
 SELECT ?r ?status_name ?author WHERE {
-  GRAPH rec:HeadContent {
     ?r a rev:Revision.
     FILTER NOT EXISTS {
-        ?new rev:replaces ?r.
+        ?new rev:isNewRevisionOf ?r.
     }
     ?review a review:Review;
-        review:aboutVersion ?r.
+        review:aboutRevision ?r.
     ?review a ?status;
         review:issuedBy ?author.
     ?status rdfs:subClassOf review:ReviewState;
         rdfs:label ?status_name .
-  }
+  
 }

--- a/doc/examples/rdfox/tagcomments.sparql
+++ b/doc/examples/rdfox/tagcomments.sparql
@@ -1,8 +1,7 @@
 SELECT distinct ?document ?revision ?comment_text ?author ?comment_responsible ?date ?tag WHERE {
-    GRAPH rec:HeadContent {
         ?reply a review:Review;
             review:issuedBy ?comment_responsible;
-            review:aboutVersion ?revision;
+            review:aboutRevision ?revision;
             review:hasComment ?comment.
         ?comment a review:Comment;
             rdfs:label ?comment_text;
@@ -11,5 +10,5 @@ SELECT distinct ?document ?revision ?comment_text ?author ?comment_responsible ?
             review:aboutObject ?row.
         ?row mel:tagNumber ?tag.
         ?revision rev:describes ?document.
-    }
+   
 }

--- a/schema/review.shacl
+++ b/schema/review.shacl
@@ -56,7 +56,7 @@ rev:RevisionReplyShape
     sh:targetClass rev:Revision ;
     sh:property 
     [ 
-        sh:path [ sh:inversePath review:aboutVersion ];
+        sh:path [ sh:inversePath review:aboutRevision ];
         sh:class review:Review;
         sh:maxCount 1;
         sh:name "RevisionReviewPath";

--- a/schema/review.ttl
+++ b/schema/review.ttl
@@ -74,12 +74,13 @@ prov:wasAssociatedWith rdf:type owl:ObjectProperty .
 
 
 ###  https://rdf.equinor.com/ontology/review/aboutVersion
-:aboutVersion rdf:type owl:ObjectProperty ;
+:aboutRevision rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf prov:wasAssociatedWith ;
               rdf:type owl:AsymmetricProperty ,
                        owl:IrreflexiveProperty ;
               rdfs:domain :Review ;
-              rdfs:comment "A review must be about a certain version or revision of data. In the case of rev:Revision, the latter contains one or more records. They represent the imutable state which the revision author(s) used for the revision process." ;
+              rdfs:range rev:Revision ;
+              rdfs:comment "A review must be about a revision of data, which contains one or more records. They represent the imutable state which the revision author(s) used for the revision process." ;
               rdfs:label "about version" .
 
 

--- a/schema/review.ttl
+++ b/schema/review.ttl
@@ -73,7 +73,7 @@ prov:wasAssociatedWith rdf:type owl:ObjectProperty .
              rdfs:label "about review" .
 
 
-###  https://rdf.equinor.com/ontology/review/aboutVersion
+###  https://rdf.equinor.com/ontology/review/aboutRevision
 :aboutRevision rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf prov:wasAssociatedWith ;
               rdf:type owl:AsymmetricProperty ,


### PR DESCRIPTION
The rename and change from aboutVersion to aboutRevision in PR #12 was not complete. This PR implements the change in the ontology file review.ttl and in several examples