### PR TITLE
Create new publish nuget action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,9 @@
-name: Publish
+name: 🚀 Build and Publish DtoTransformer 🚀
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - ".*src/DtoTransformer/DtoTransformer.*"
-  
+  release:
+    types: [published] 
+
 jobs:
   publish:
     name: "Nuget publish"
@@ -18,9 +14,15 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+
       - name: Restore dependencies
         run: dotnet restore ./src/DtoTransformer/DtoTransformer
-      - name: Build
-        run: dotnet build ./src/DtoTransformer/DtoTransformer -c release --no-restore  /p:'ReleaseType="";description="A library for using revisions."'
+
+      - name: Build solution
+        run: dotnet build ./src/DtoTransformer/DtoTransformer --no-restore --configuration Release 
+
+      - name: Create artifact
+        run: dotnet pack ./src/DtoTransformer/DtoTransformer --no-restore --no-build --configuration Release --output ${{ github.workspace }}/out /p:'description="A library for using revisions.";PackageVersion="${{ github.event.release.name }}'
+
       - name: Publish
-        run: dotnet nuget push ./src/DtoTransformer/DtoTransformer/bin/release/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }}  --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ${{ github.workspace }}/out/Review*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/src/DtoTransformer/DtoTransformer/DtoTransformer.csproj
+++ b/src/DtoTransformer/DtoTransformer/DtoTransformer.csproj
@@ -9,7 +9,6 @@
     <Description>Package for transforming DTO to RDF, and vice-versa</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <PackageId>Review</PackageId>
-	  <VersionPrefix>4.0.5</VersionPrefix>
       <PackageLicenseExpression>GPL-2.0-or-later</PackageLicenseExpression>
 	  <PublishRepositoryUrl>true</PublishRepositoryUrl>
 	  <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Link to [user story](https://dev.azure.com/EquinorASA/Spine/_boards/board/t/Semantic%20Infrastucture/Stories/?workitem=161191) 

The action for publishing the nuget package will now be triggered on release. The name of the release will be used as the version of the nuget package. Because of this the version is deleted from the csproj file. 