### PR TITLE
Update Dto and Rdf Generator

### DIFF
--- a/src/DtoTransformer/DtoTransformer/DtoGenerator.cs
+++ b/src/DtoTransformer/DtoTransformer/DtoGenerator.cs
@@ -1,4 +1,5 @@
-﻿using VDS.RDF;
+﻿using DtoTransformer;
+using VDS.RDF;
 using VDS.RDF.Query;
 
 
@@ -13,13 +14,12 @@ public class DtoGenerator
                 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
                 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
-                prefix exdata: <https://example.com/data/>
-                prefix exdoc: <https://example.com/doc/>
                 prefix rec: <https://rdf.equinor.com/ontology/record/>
                 prefix rev: <https://rdf.equinor.com/ontology/revision/>
                 prefix rdl: <http://example.com/rdl/>
                 prefix mel: <https://rdf.equinor.com/ontology/mel/v1#>
-                SELECT DISTINCT ?reviewId ?aboutRevision ?issuedBy ?generatedAtTime ?reviewStatus ?label ?guid
+                prefix eq: <https://rdf.equinor.com/>
+                SELECT DISTINCT ?reviewId ?aboutRevision ?tr ?issuedBy ?generatedAtTime ?reviewStatus ?label ?guid
                 WHERE {
                     ?reviewId a review:Review ;
                                 review:aboutRevision ?aboutRevision ;
@@ -28,6 +28,7 @@ public class DtoGenerator
                                 rdf:type ?reviewStatus ;
                                 rdfs:label ?label .
                     OPTIONAL{?reviewId review:hasGuid ?guid} .
+                    OPTIONAL{?reviewId review:reviewOfClass ?tr} .
                     FILTER (?reviewStatus != review:Review)
                 }";
 
@@ -49,6 +50,7 @@ public class DtoGenerator
         reviewDto.GeneratedAtTime = DateOnly.Parse(((LiteralNode)reviewResult["generatedAtTime"]).Value);
         reviewDto.Status = ParseReviewStatus(reviewResult["reviewStatus"].ToString());
         reviewDto.Label = ((LiteralNode)reviewResult["label"]).Value;
+        reviewDto.TechnicalRequirement = TRExtensions.StringUriToTR(reviewResult["tr"].ToString()); 
         reviewDto.HasComments = new List<CommentDto>();
 
 

--- a/src/DtoTransformer/DtoTransformer/DtoGenerator.cs
+++ b/src/DtoTransformer/DtoTransformer/DtoGenerator.cs
@@ -50,7 +50,7 @@ public class DtoGenerator
         reviewDto.GeneratedAtTime = DateOnly.Parse(((LiteralNode)reviewResult["generatedAtTime"]).Value);
         reviewDto.Status = ParseReviewStatus(reviewResult["reviewStatus"].ToString());
         reviewDto.Label = ((LiteralNode)reviewResult["label"]).Value;
-        reviewDto.TechnicalRequirement = TRExtensions.StringUriToTR(reviewResult["tr"].ToString()); 
+        reviewDto.TechnicalRequirement = reviewResult.HasValue("tr") ? TRExtensions.StringUriToTR(reviewResult["tr"].ToString()) : TR.None;
         reviewDto.HasComments = new List<CommentDto>();
 
 

--- a/src/DtoTransformer/DtoTransformer/Namespaces.cs
+++ b/src/DtoTransformer/DtoTransformer/Namespaces.cs
@@ -50,6 +50,7 @@ public struct Namespaces
         public const string hasAttachment = $"{BaseUrl}hasAttachment";
         public const string revisionSequenceNumber = $"{BaseUrl}hasSequenceNumber";
     }
+
     public struct Review
     {
         public const string BaseUrl = "https://rdf.equinor.com/ontology/review/";
@@ -62,6 +63,7 @@ public struct Namespaces
         public const string FilterObject = $"{BaseUrl}FilterObject";
         public const string HasComment = $"{BaseUrl}hasComment";
         public const string HasGuid = $"{BaseUrl}hasGuid";
+        public const string ReviewOfClass = $"{BaseUrl}reviewOfClass";
     }
     public struct Data
     {

--- a/src/DtoTransformer/DtoTransformer/RdfGenerator.cs
+++ b/src/DtoTransformer/DtoTransformer/RdfGenerator.cs
@@ -1,11 +1,13 @@
-﻿using VDS.RDF;
+﻿using DtoTransformer;
+using VDS.RDF;
+using VDS.RDF.Query.Algebra;
 
 namespace Review;
 public class RdfGenerator
 {
-    public static Graph GenerateRdf(ReviewDTO reviewDto)
+    public static VDS.RDF.Graph GenerateRdf(ReviewDTO reviewDto)
     {
-        var graph = new Graph();
+        var graph = new VDS.RDF.Graph();
         //Add nAmespaces
         graph.NamespaceMap.AddNamespace("rdf", new Uri(Namespaces.Rdf.BaseUrl));
         graph.NamespaceMap.AddNamespace("rdfs", new Uri(Namespaces.Rdfs.BaseUrl));
@@ -29,9 +31,13 @@ public class RdfGenerator
         graph.Assert(new Triple(reviewId, graph.CreateUriNode("rdf:type"), reviewStatus));
         graph.Assert(new Triple(reviewId, graph.CreateUriNode("rdfs:label"), label));
         graph.Assert(new Triple(reviewId, graph.CreateUriNode("prov:generatedAtTime"), generatedAtTime));
-        graph.Assert(new Triple(reviewId, graph.CreateUriNode("review:aboutRevision"), aboutRevision));
         graph.Assert(new Triple(reviewId, graph.CreateUriNode("review:issuedBy"), issuedBy));
         graph.Assert(new Triple(reviewId, graph.CreateUriNode(new Uri(Namespaces.Review.HasGuid)), guidvalue));
+        graph.Assert(new Triple(reviewId, graph.CreateUriNode("review:aboutRevision"), aboutRevision));
+        if (reviewDto.TechnicalRequirement != TR.None)
+            graph.Assert(new Triple(reviewId, graph.CreateUriNode(new Uri(Namespaces.Review.ReviewOfClass)), graph.CreateUriNode(reviewDto.TechnicalRequirement.ToUri())));
+       
+
 
         //Create and assert comment triples
         foreach (var commentDto in reviewDto.HasComments)
@@ -83,7 +89,7 @@ public class RdfGenerator
         return date.ToString("yyyy-MM-dd");
     }
 
-    public static void AddBlankNodeToReview(Graph graph, IRefNode rdfSubject)
+    public static void AddBlankNodeToReview(VDS.RDF.Graph graph, IRefNode rdfSubject)
     {
         IRefNode activity = graph.CreateBlankNode();
         AddProvenance(graph, activity);
@@ -96,7 +102,7 @@ public class RdfGenerator
         graph.Assert(wasGeneratedByPredicate);
     }
 
-    private static void AddProvenance(Graph graph, IRefNode activity)
+    private static void AddProvenance(VDS.RDF.Graph graph, IRefNode activity)
     {
         var versionUri = new UriNode(new Uri(CreateReviewVersionUri()));
         graph.Assert(new Triple(

--- a/src/DtoTransformer/DtoTransformer/TR.cs
+++ b/src/DtoTransformer/DtoTransformer/TR.cs
@@ -10,10 +10,17 @@ public static class TRExtensions
 {
     public const string MelReportingTemplateUri = "https://rdf.equinor.com/ontology/technical-requirement/v1#MelReportingTemplate";
 
-    public static string ToUri(this TR type) =>
+    public static Uri ToUri(this TR type) =>
         type switch
         {
-            TR.MelReportingTemplate => MelReportingTemplateUri,
+            TR.MelReportingTemplate => new Uri(MelReportingTemplateUri),
             _ => throw new ArgumentOutOfRangeException(nameof(type))
+        };
+
+    public static TR StringUriToTR(string stringUri) =>
+        stringUri switch
+        {
+            MelReportingTemplateUri => TR.MelReportingTemplate,
+            _ => throw new ArgumentOutOfRangeException(stringUri)
         };
 }

--- a/src/DtoTransformer/Tests/Tests.cs
+++ b/src/DtoTransformer/Tests/Tests.cs
@@ -25,22 +25,7 @@ namespace Review.Tests
             var reviewDtoAfterTransformation = DtoGenerator.GenerateDto(graph);
 
             // Assert
-            Assert.Equal(reviewDto.ReviewGuid, reviewDtoAfterTransformation.ReviewGuid);
-            Assert.Equal(reviewDto.IssuedBy, reviewDtoAfterTransformation.IssuedBy);
-            Assert.Equal(reviewDto.Label, reviewDtoAfterTransformation.Label);
-
-            for (int i = 0; i < reviewDto.HasComments.Count; i++)
-            {
-                var expectedComment = reviewDto.HasComments[i];
-                var actualComment = reviewDtoAfterTransformation.HasComments[i];
-
-                Guid parsedGuid;
-                bool isValidGuid = Guid.TryParse(actualComment.CommentId.ToString(), out parsedGuid);
-                Assert.True(isValidGuid, "The CommentId is not a valid GUID.");
-
-                Assert.False(string.IsNullOrEmpty(actualComment.CommentText), "The CommentText should not be null or empty.");
-
-            }
+            reviewDtoAfterTransformation.Should().BeEquivalentTo(reviewDto);
         }
 
         [Fact]
@@ -176,6 +161,7 @@ namespace Review.Tests
             {
                 ReviewIri = "https://example.com/doc/reply-A123-BC-D-EF-00001.F01",
                 AboutRevision = new Uri("https://example.com/data/A123-BC-D-EF-00001.F01"),
+                TechnicalRequirement = DtoTransformer.TR.MelReportingTemplate,
                 IssuedBy = "Turi Skogen",
                 GeneratedAtTime = DateOnly.FromDateTime(DateTime.Now),
                 Status = ReviewStatus.Code1,


### PR DESCRIPTION
In a previous pull request the property TechnicalRequirement was added to the ReviewDTO. When adding this the RdfGenerator and DtoGenerator was not taken into account. When transforming the ReviewDTO to RDF there was no trace of the TechnicalRequirement, and when transforming the RDF back into the ReviewDTO it would not be equal.
This PR addresses this issue. 