### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # For DtoTransformer
+    directory: "/src/DtoTransformer/DtoTransformer" # Path to the .csproj file
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+
+  - package-ecosystem: "nuget" # For DtoTransformerNugetTest
+    directory: "/src/DtoTransformerNugetTest" # Path to the .csproj file
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"


### PR DESCRIPTION
### [User Story 185652](https://dev.azure.com/EquinorASA/Spine/_workitems/edit/185652): BUG: Dependabot mangler på DtoTransformer i revisions

### Description
I have enabled Dependabot in this repository and created a dependabot.yml file which will create PRs for nuget package upgrades each monday in both the DtoTransformer and DtoTransformetNugetTest projects.